### PR TITLE
change subject.unsubscribe() to subject.complete()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ dist
 
 # Docs
 gh-pages
+
+# VScode stop adding .angulardoc.json
+.angulardoc.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimate/ngxerrors",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "A declarative validation module for reactive forms",
   "author": "Ultimate Angular",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ultimate/ngxerrors",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "A declarative validation module for reactive forms",
   "author": "Ultimate Angular",
   "license": "MIT",

--- a/src/ngxerror.directive.ts
+++ b/src/ngxerror.directive.ts
@@ -70,6 +70,7 @@ export class NgxErrorDirective implements OnInit, OnDestroy, DoCheck {
   }
 
   ngOnDestroy() {
+    this._states.complete();
     this.subscription.unsubscribe();
   }
 

--- a/src/ngxerrors.directive.ts
+++ b/src/ngxerrors.directive.ts
@@ -16,7 +16,7 @@ export class NgxErrorsDirective implements OnChanges, OnDestroy, AfterViewInit {
   @Input('ngxErrors')
   controlName: string;
 
-  subject = new BehaviorSubject<ErrorDetails>(null);
+  subject: BehaviorSubject<ErrorDetails>;
 
   control: AbstractControl;
 
@@ -71,10 +71,14 @@ export class NgxErrorsDirective implements OnChanges, OnDestroy, AfterViewInit {
     }
   }
 
+  ngOnInit() {
+    this.subject = new BehaviorSubject<ErrorDetails>(null);
+  }
+
   ngOnChanges() {
     this.control = this.form.control.get(this.controlName);
   }
-  
+
   ngAfterViewInit() {
     setTimeout(() => {
       this.checkStatus();
@@ -83,7 +87,7 @@ export class NgxErrorsDirective implements OnChanges, OnDestroy, AfterViewInit {
   }
 
   ngOnDestroy() {
-    this.subject.unsubscribe();
+    this.subject.complete();
   }
 
 }


### PR DESCRIPTION
<!-- Nice one! You're submitting a pull request. Please give us as much information as possible to help get it merged quicker! -->
This pull request is related to a bug I found out when testing the ngx-errors to use on my project. I discovered that another user had already opened an issue #22 .
The bug occurs because the `BehaviorSubject` is closed when `ngOnDestroy` is called, but don't recieve another instance when a new component is created, making it impossible to use this component with `ngIf` directive.
Hunting down this bug I found out that the `BehaviorSubject` references was kind of "dirty" because it was being `unsubscribed()` when the `ngOnDestroy` from `ngxerrors` was being called. 
As the `ngxerrors` wasn't subscribing to it, there was no reason to `unsubscribe()`, to leave this reference you should complete the subject as the `ngxerrors` is it's manager. 
By completing it, all subscriptions should be already unsubscribed and the components was ready to receive other instance of `BehaviorSubject` when a new component is created.
And passed the instantiation of the `BehaviorSubject` to the `ngOnInit` lifecycle hook.

**What are you adding/fixing?**
Bug fix #22

**Have you added tests for your changes?**
I tried to add, but failed. I couldn't test if the `fixture.detectChanges()` was triggering and error.

**Will this need documentation changes?**
<!-- If yes, docs will need to be changed (not necessarily by you!) before this can get merged. If you've changed the docs (you're awesome), say so here. If not (don't worry, you're still awesome), feel free to submit your PR still and someone will come along and write them up -->
No

**Does this introduce a breaking change?**
<!-- If your change make a breaking change, please include as much information as possible and the reasoning behind the changes -->
No

**Other information**